### PR TITLE
Drop singularity from pilot2 wrapper

### DIFF
--- a/runpilot2-wrapper.sh
+++ b/runpilot2-wrapper.sh
@@ -5,7 +5,7 @@
 #
 # https://google.github.io/styleguide/shell.xml
 
-VERSION=20190801a-pilot2
+VERSION=20190802a-pilot2
 
 function err() {
   dt=$(date --utc +"%Y-%m-%d %H:%M:%S %Z [wrapper]")


### PR DESCRIPTION
I already saw users confused by messages in job stdout, because pilot2 wrapper logs it is not using singularity container - it would be better to completely drop this code, because containers are now handled directly by pilot2 code.