### PR TITLE
Use shoal to set the frontier proxy

### DIFF
--- a/runpilot2-wrapper.sh
+++ b/runpilot2-wrapper.sh
@@ -147,6 +147,22 @@ function setup_local() {
   fi
 }
 
+function setup_shoal() {
+  log "will set FRONTIER_SERVER with shoal"
+  if [[ -n "${FRONTIER_SERVER}" ]] ; then
+    export FRONTIER_SERVER
+    log "call shoal frontier"
+    outputstr=`shoal-client -f`
+    log "result: $outputstr"
+
+    if [[ $? -eq 0 ]] ; then
+      export FRONTIER_SERVER=$outputstr
+    fi
+
+    log "set FRONTIER_SERVER = $FRONTIER_SERVER"
+  fi
+}
+
 function check_vomsproxyinfo() {
   out=$(voms-proxy-info --version 2>/dev/null)
   if [[ $? -eq 0 ]]; then
@@ -361,6 +377,12 @@ function main() {
   setup_local
   echo
 
+  if [[ "${shoalflag}" == 'true' ]]; then
+    echo "--- Setup shoal ---"
+    setup_shoal
+    echo
+  fi
+
   echo "---- Proxy Information ----"
   if [[ ${tflag} == 'true' ]]; then
     log 'Skipping proxy checks due to -t flag'
@@ -441,6 +463,7 @@ jarg='managed'
 qarg=''
 rarg=''
 sarg=''
+shoalflag=false
 tflag='false'
 piloturl='http://pandaserver.cern.ch:25085/cache/pilot/pilot2.tar.gz'
 mute='false'
@@ -488,6 +511,10 @@ case $key in
     -s)
     sarg="$2"
     shift
+    shift
+    ;;
+    -S|--shoal)
+    shoalflag=true
     shift
     ;;
     -t)

--- a/runpilot3-wrapper.sh
+++ b/runpilot3-wrapper.sh
@@ -403,6 +403,23 @@ function nordugrid_post_processing() {
 }
 
 
+function setup_shoal() {
+  log "will set FRONTIER_SERVER with shoal"
+  if [[ -n "${FRONTIER_SERVER}" ]] ; then
+    export FRONTIER_SERVER
+    log "call shoal frontier"
+    outputstr=`shoal-client -f`
+    log "result: $outputstr"
+
+    if [[ $? -eq 0 ]] ; then
+      export FRONTIER_SERVER=$outputstr
+    fi
+
+  log "set FRONTIER_SERVER = $FRONTIER_SERVER"
+  fi
+}
+
+
 function sortie() {
   ec=$1
   if [[ $ec -eq 0 ]]; then
@@ -418,6 +435,7 @@ function sortie() {
   err "==== wrapper stderr END ===="
   exit $ec
 }
+
 
 function main() {
   #
@@ -533,6 +551,12 @@ function main() {
   setup_local
   echo
 
+  if [[ "${shoalflag}" == 'true' ]]; then
+    echo "--- Setup shoal ---"
+    setup_shoal
+    echo
+  fi
+
   echo "---- Proxy Information ----"
   check_proxy
   echo
@@ -618,7 +642,8 @@ sflag=''
 uflag=''
 wflag=''
 Fflag=''
-while getopts 'C:f:h:i:p:s:u:w:F:' flag; do
+shoalflag=false
+while getopts 'C:f:h:i:p:s:u:w:F:S' flag; do
   case "${flag}" in
     C) Cflag="${OPTARG}" ;;
     f) fflag="${OPTARG}" ;;
@@ -632,6 +657,7 @@ while getopts 'C:f:h:i:p:s:u:w:F:' flag; do
     A) aflag="${OPTARG}" ;;
     v) vflag="${OPTARG}" ;;
     o) oflag="${OPTARG}" ;;
+    S) shoalflag=true ;;
     *) log "Unexpected option ${flag}" ;;
   esac
 done


### PR DESCRIPTION
After the local setup has run and filled the FRONTIER_SERVER environmental variable augment it by adding the nearest proxies from shoal. Only do this if the -S or --shoal flag is set.

This is necessary in the wrapper since auto-setup does not use shoal. Not sure the wrapper is the right place for this, but I have never been able to get it into the auto-setup.

I've been using this on the could queues for the past month with shoal and at P1 without shoal.

Cheers,
-Frank